### PR TITLE
feat: load cards from JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ name = "satori-core"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Satori 是一个中文黑话和网络梗语义搜索项目。
 
 当前版本先打通 API、数据结构和测试链路。
 
-搜索接口现在使用固定 fixture 数据和简单关键词排序。
+搜索接口现在读取本地 JSON 卡片，并使用简单关键词排序。
 
 ## 数据卡片
 
@@ -125,6 +125,14 @@ cargo run -p satori-api
 
 默认监听地址是 `127.0.0.1:3000`。
 
+默认语料路径是 `data/processed/cards.json`。
+
+可以用 `SATORI_CARDS_PATH` 指定其他 JSON 文件。
+
+```bash
+SATORI_CARDS_PATH=tests/fixtures/cards.json cargo run -p satori-api
+```
+
 检查健康状态。
 
 ```bash
@@ -156,7 +164,7 @@ tests/
 
 `crates/indexer` 目前保留为索引构建入口。
 
-当前搜索实现使用固定 fixture 数据和简单关键词排序。
+当前搜索实现读取本地 JSON 卡片，并使用简单关键词排序。
 
 ## 当前状态
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -119,10 +119,11 @@ mod tests {
     async fn search_returns_matching_card() {
         let cards = fixture_cards();
         let query = cards[0].plain.clone();
-        let response = app(AppState::new(fixture_cards()))
+        let encoded_query = urlencoding::encode(&query);
+        let response = app(AppState::new(cards))
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/search?q={query}"))
+                    .uri(format!("/api/search?q={encoded_query}"))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -92,24 +92,12 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
+    use satori_core::load_cards_from_reader;
     use tower::ServiceExt;
 
     fn fixture_cards() -> Vec<JargonCard> {
-        vec![JargonCard {
-            id: "jargon_lar_tong_dui_qi".to_owned(),
-            term: "拉通对齐".to_owned(),
-            plain: "大家先统一想法".to_owned(),
-            explanation: "让相关的人先把目标、分工和时间说清楚。".to_owned(),
-            examples: vec!["这个需求先拉通对齐一下。".to_owned()],
-            queries: vec![
-                "大家先统一想法".to_owned(),
-                "先把要做的事情说清楚".to_owned(),
-                "几个人先同步一下".to_owned(),
-            ],
-            tags: vec!["职场".to_owned(), "会议".to_owned(), "协作".to_owned()],
-            source: "manual".to_owned(),
-            verified: true,
-        }]
+        load_cards_from_reader(include_str!("../../../tests/fixtures/cards.json").as_bytes())
+            .expect("parse cards fixture JSON")
     }
 
     #[tokio::test]
@@ -129,10 +117,12 @@ mod tests {
 
     #[tokio::test]
     async fn search_returns_matching_card() {
+        let cards = fixture_cards();
+        let query = cards[0].plain.clone();
         let response = app(AppState::new(fixture_cards()))
             .oneshot(
                 Request::builder()
-                    .uri("/api/search?q=大家先统一想法")
+                    .uri(format!("/api/search?q={query}"))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -85,24 +85,6 @@ impl IntoResponse for ApiError {
     }
 }
 
-pub fn fixture_cards() -> Vec<JargonCard> {
-    vec![JargonCard {
-        id: "jargon_lar_tong_dui_qi".to_owned(),
-        term: "拉通对齐".to_owned(),
-        plain: "大家先统一想法".to_owned(),
-        explanation: "让相关的人先把目标、分工和时间说清楚。".to_owned(),
-        examples: vec!["这个需求先拉通对齐一下。".to_owned()],
-        queries: vec![
-            "大家先统一想法".to_owned(),
-            "先把要做的事情说清楚".to_owned(),
-            "几个人先同步一下".to_owned(),
-        ],
-        tags: vec!["职场".to_owned(), "会议".to_owned(), "协作".to_owned()],
-        source: "manual".to_owned(),
-        verified: true,
-    }]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,6 +93,24 @@ mod tests {
         http::{Request, StatusCode},
     };
     use tower::ServiceExt;
+
+    fn fixture_cards() -> Vec<JargonCard> {
+        vec![JargonCard {
+            id: "jargon_lar_tong_dui_qi".to_owned(),
+            term: "拉通对齐".to_owned(),
+            plain: "大家先统一想法".to_owned(),
+            explanation: "让相关的人先把目标、分工和时间说清楚。".to_owned(),
+            examples: vec!["这个需求先拉通对齐一下。".to_owned()],
+            queries: vec![
+                "大家先统一想法".to_owned(),
+                "先把要做的事情说清楚".to_owned(),
+                "几个人先同步一下".to_owned(),
+            ],
+            tags: vec!["职场".to_owned(), "会议".to_owned(), "协作".to_owned()],
+            source: "manual".to_owned(),
+            verified: true,
+        }]
+    }
 
     #[tokio::test]
     async fn health_returns_ok() {

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1,15 +1,24 @@
 use anyhow::Context;
-use satori_api::{AppState, app, fixture_cards};
+use satori_api::{AppState, app};
+use satori_core::load_cards_from_reader;
+use std::{env, fs::File};
 use tokio::net::TcpListener;
+
+const DEFAULT_CARDS_PATH: &str = "data/processed/cards.json";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let address = "127.0.0.1:3000";
+    let cards_path =
+        env::var("SATORI_CARDS_PATH").unwrap_or_else(|_| DEFAULT_CARDS_PATH.to_owned());
+    let cards_file =
+        File::open(&cards_path).with_context(|| format!("failed to open {cards_path}"))?;
+    let cards = load_cards_from_reader(cards_file).context("failed to load jargon cards")?;
     let listener = TcpListener::bind(address)
         .await
         .with_context(|| format!("failed to bind {address}"))?;
 
-    axum::serve(listener, app(AppState::new(fixture_cards())))
+    axum::serve(listener, app(AppState::new(cards)))
         .await
         .context("api server failed")?;
 

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -13,7 +13,8 @@ async fn main() -> anyhow::Result<()> {
         env::var("SATORI_CARDS_PATH").unwrap_or_else(|_| DEFAULT_CARDS_PATH.to_owned());
     let cards_file =
         File::open(&cards_path).with_context(|| format!("failed to open {cards_path}"))?;
-    let cards = load_cards_from_reader(cards_file).context("failed to load jargon cards")?;
+    let cards = load_cards_from_reader(cards_file)
+        .with_context(|| format!("failed to load jargon cards from {cards_path}"))?;
     let listener = TcpListener::bind(address)
         .await
         .with_context(|| format!("failed to bind {address}"))?;

--- a/crates/api/tests/smoke.rs
+++ b/crates/api/tests/smoke.rs
@@ -2,8 +2,10 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
-use satori_api::{AppState, app, fixture_cards};
+use satori_api::{AppState, app};
+use satori_core::{JargonCard, load_cards_from_reader};
 use serde_json::Value;
+use std::{fs::File, path::PathBuf};
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -24,6 +26,18 @@ async fn health_endpoint_returns_ok_status() {
     let payload: Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(payload["status"], "ok");
+}
+
+fn fixture_cards() -> Vec<JargonCard> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("tests")
+        .join("fixtures")
+        .join("cards.json");
+    let file = File::open(path).unwrap();
+
+    load_cards_from_reader(file).unwrap()
 }
 
 #[tokio::test]

--- a/crates/api/tests/smoke.rs
+++ b/crates/api/tests/smoke.rs
@@ -42,10 +42,16 @@ fn fixture_cards() -> Vec<JargonCard> {
 
 #[tokio::test]
 async fn search_endpoint_returns_expected_shape() {
+    let cards = fixture_cards();
+    let query = cards[0].plain.clone();
+    let expected_term = cards[0].term.clone();
     let response = app(AppState::new(fixture_cards()))
         .oneshot(
             Request::builder()
-                .uri("/api/search?q=大家先统一想法&limit=5")
+                .uri(format!(
+                    "/api/search?q={}&limit=5",
+                    urlencoding::encode(&query)
+                ))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -57,8 +63,8 @@ async fn search_endpoint_returns_expected_shape() {
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let payload: Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(payload["query"], "大家先统一想法");
+    assert_eq!(payload["query"], query);
     assert!(payload["results"].is_array());
-    assert_eq!(payload["results"][0]["term"], "拉通对齐");
+    assert_eq!(payload["results"][0]["term"], expected_term);
     assert!(payload["results"][0]["score"].is_number());
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,3 +7,4 @@ repository.workspace = true
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -80,7 +80,14 @@ impl fmt::Display for CardLoadError {
     }
 }
 
-impl Error for CardLoadError {}
+impl Error for CardLoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Json(error) => Some(error),
+            Self::Empty => None,
+        }
+    }
+}
 
 impl From<serde_json::Error> for CardLoadError {
     fn from(error: serde_json::Error) -> Self {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -168,35 +168,28 @@ fn keyword_score(query: &str, card: &JargonCard) -> f32 {
 mod tests {
     use super::*;
 
+    fn fixture_cards() -> Vec<JargonCard> {
+        load_cards_from_reader(include_str!("../../../tests/fixtures/cards.json").as_bytes())
+            .expect("parse cards fixture JSON")
+    }
+
     fn card() -> JargonCard {
-        JargonCard {
-            id: "jargon_lar_tong_dui_qi".to_owned(),
-            term: "拉通对齐".to_owned(),
-            plain: "大家先统一想法".to_owned(),
-            explanation: "让相关的人先把目标、分工和时间说清楚。".to_owned(),
-            examples: vec!["这个需求先拉通对齐一下。".to_owned()],
-            queries: vec!["先把要做的事情说清楚".to_owned()],
-            tags: vec!["职场".to_owned(), "会议".to_owned()],
-            source: "manual".to_owned(),
-            verified: true,
-        }
+        fixture_cards().remove(0)
     }
 
     #[test]
     fn searchable_text_contains_card_fields() {
-        let text = card().searchable_text();
+        let card = card();
+        let text = card.searchable_text();
 
-        assert!(text.contains("拉通对齐"));
-        assert!(text.contains("大家先统一想法"));
-        assert!(text.contains("会议"));
+        assert!(text.contains(&card.term));
+        assert!(text.contains(&card.plain));
+        assert!(card.tags.iter().any(|tag| text.contains(tag)));
     }
 
     #[test]
     fn normalize_query_trims_input() {
-        assert_eq!(
-            normalize_query("  拉通对齐  ", 20),
-            Ok("拉通对齐".to_owned())
-        );
+        assert_eq!(normalize_query("  query  ", 20), Ok("query".to_owned()));
     }
 
     #[test]
@@ -215,34 +208,18 @@ mod tests {
     #[test]
     fn rank_keyword_matches_returns_expected_card() {
         let card = card();
-        let results = rank_keyword_matches("大家先统一想法", [&card], 3);
+        let results = rank_keyword_matches(&card.plain, [&card], 3);
 
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].id, "jargon_lar_tong_dui_qi");
+        assert_eq!(results[0].id, card.id);
     }
 
     #[test]
     fn load_cards_from_reader_reads_json_cards() {
-        let json = r#"
-            [
-              {
-                "id": "jargon_lar_tong_dui_qi",
-                "term": "拉通对齐",
-                "plain": "大家先统一想法",
-                "explanation": "让相关的人先把目标、分工和时间说清楚。",
-                "examples": ["这个需求先拉通对齐一下。"],
-                "queries": ["先把要做的事情说清楚"],
-                "tags": ["职场", "会议"],
-                "source": "manual",
-                "verified": true
-              }
-            ]
-        "#;
-
-        let cards = load_cards_from_reader(json.as_bytes()).unwrap();
+        let cards = fixture_cards();
 
         assert_eq!(cards.len(), 1);
-        assert_eq!(cards[0].term, "拉通对齐");
+        assert!(!cards[0].term.is_empty());
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -224,9 +224,11 @@ mod tests {
     #[test]
     fn load_cards_from_reader_reads_json_cards() {
         let cards = fixture_cards();
+        let first = cards.first().expect("fixture should contain cards");
 
-        assert_eq!(cards.len(), 1);
-        assert!(!cards[0].term.is_empty());
+        assert!(!first.id.is_empty());
+        assert!(!first.term.is_empty());
+        assert!(!first.plain.is_empty());
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::{error::Error, fmt, io::Read};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JargonCard {
@@ -62,6 +63,39 @@ pub struct SearchResponse {
 pub enum SearchQueryError {
     Empty,
     TooLong { max_chars: usize },
+}
+
+#[derive(Debug)]
+pub enum CardLoadError {
+    Json(serde_json::Error),
+    Empty,
+}
+
+impl fmt::Display for CardLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Json(error) => write!(formatter, "invalid card JSON: {error}"),
+            Self::Empty => formatter.write_str("card collection is empty"),
+        }
+    }
+}
+
+impl Error for CardLoadError {}
+
+impl From<serde_json::Error> for CardLoadError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+pub fn load_cards_from_reader(reader: impl Read) -> Result<Vec<JargonCard>, CardLoadError> {
+    let cards: Vec<JargonCard> = serde_json::from_reader(reader)?;
+
+    if cards.is_empty() {
+        return Err(CardLoadError::Empty);
+    }
+
+    Ok(cards)
 }
 
 pub fn normalize_query(input: &str, max_chars: usize) -> Result<String, SearchQueryError> {
@@ -185,5 +219,45 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "jargon_lar_tong_dui_qi");
+    }
+
+    #[test]
+    fn load_cards_from_reader_reads_json_cards() {
+        let json = r#"
+            [
+              {
+                "id": "jargon_lar_tong_dui_qi",
+                "term": "拉通对齐",
+                "plain": "大家先统一想法",
+                "explanation": "让相关的人先把目标、分工和时间说清楚。",
+                "examples": ["这个需求先拉通对齐一下。"],
+                "queries": ["先把要做的事情说清楚"],
+                "tags": ["职场", "会议"],
+                "source": "manual",
+                "verified": true
+              }
+            ]
+        "#;
+
+        let cards = load_cards_from_reader(json.as_bytes()).unwrap();
+
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].term, "拉通对齐");
+    }
+
+    #[test]
+    fn load_cards_from_reader_rejects_empty_collection() {
+        assert!(matches!(
+            load_cards_from_reader("[]".as_bytes()),
+            Err(CardLoadError::Empty)
+        ));
+    }
+
+    #[test]
+    fn load_cards_from_reader_rejects_invalid_json() {
+        assert!(matches!(
+            load_cards_from_reader("not json".as_bytes()),
+            Err(CardLoadError::Json(_))
+        ));
     }
 }

--- a/data/processed/cards.json
+++ b/data/processed/cards.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "jargon_lar_tong_dui_qi",
+    "term": "拉通对齐",
+    "plain": "大家先统一想法",
+    "explanation": "让相关的人先把目标、分工和时间说清楚。",
+    "examples": [
+      "这个需求先拉通对齐一下。"
+    ],
+    "queries": [
+      "大家先统一想法",
+      "先把要做的事情说清楚",
+      "几个人先同步一下"
+    ],
+    "tags": ["职场", "会议", "协作"],
+    "source": "manual",
+    "verified": true
+  }
+]


### PR DESCRIPTION
## Summary
- Add core JSON loading for jargon cards.
- Reject empty card collections and invalid JSON.
- Load API cards from data/processed/cards.json by default.
- Allow SATORI_CARDS_PATH to override the card file path.
- Keep tests on JSON fixtures instead of a public hardcoded fixture function.
- Update README with the local data file workflow.

## Tests
- cargo fmt --all -- --check
- cargo test --workspace

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now loads jargon cards from JSON at startup; path configurable via SATORI_CARDS_PATH (default: data/processed/cards.json).
  * Improved startup error reporting when the card file cannot be opened or parsed.

* **Documentation**
  * README updated with configuration instructions and an example for running with custom card files.

* **Chores**
  * Added a sample processed jargon card to the dataset.

* **Tests**
  * Test suite updated to load and assert against fixture JSON cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->