### PR TITLE
feat: validate card data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ name = "satori-indexer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "satori-core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ GET /api/health
 cargo test --workspace
 ```
 
+校验本地语料。
+
+```bash
+cargo run -p satori-indexer
+```
+
 启动 API 服务。
 
 ```bash
@@ -131,6 +137,12 @@ cargo run -p satori-api
 
 ```bash
 SATORI_CARDS_PATH=tests/fixtures/cards.json cargo run -p satori-api
+```
+
+也可以让校验命令读取指定文件。
+
+```bash
+cargo run -p satori-indexer -- tests/fixtures/cards.json
 ```
 
 检查健康状态。
@@ -162,7 +174,7 @@ tests/
 
 `crates/core` 提供检索卡片、搜索结果和基础排序逻辑。
 
-`crates/indexer` 目前保留为索引构建入口。
+`crates/indexer` 目前提供本地语料校验命令。
 
 当前搜索实现读取本地 JSON 卡片，并使用简单关键词排序。
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{error::Error, fmt, io::Read};
+use std::{collections::HashSet, error::Error, fmt, io::Read};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JargonCard {
@@ -71,6 +71,44 @@ pub enum CardLoadError {
     Empty,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CardValidationIssue {
+    pub card_id: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CardValidationError {
+    pub issues: Vec<CardValidationIssue>,
+}
+
+impl CardValidationError {
+    fn new(issues: Vec<CardValidationIssue>) -> Self {
+        Self { issues }
+    }
+}
+
+impl fmt::Display for CardValidationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            formatter,
+            "card validation failed with {} issue(s)",
+            self.issues.len()
+        )?;
+
+        for issue in &self.issues {
+            match &issue.card_id {
+                Some(card_id) => writeln!(formatter, "- {card_id}: {}", issue.message)?,
+                None => writeln!(formatter, "- {}", issue.message)?,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Error for CardValidationError {}
+
 impl fmt::Display for CardLoadError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -103,6 +141,74 @@ pub fn load_cards_from_reader(reader: impl Read) -> Result<Vec<JargonCard>, Card
     }
 
     Ok(cards)
+}
+
+pub fn validate_cards(cards: &[JargonCard]) -> Result<(), CardValidationError> {
+    let mut issues = Vec::new();
+    let mut seen_ids = HashSet::new();
+
+    for card in cards {
+        let card_id = card_id_for_issue(card);
+
+        check_required_field(&mut issues, &card_id, "id", &card.id);
+        check_required_field(&mut issues, &card_id, "term", &card.term);
+        check_required_field(&mut issues, &card_id, "plain", &card.plain);
+        check_required_field(&mut issues, &card_id, "explanation", &card.explanation);
+        check_required_field(&mut issues, &card_id, "source", &card.source);
+
+        if !card.id.trim().is_empty() && !seen_ids.insert(card.id.trim().to_owned()) {
+            issues.push(CardValidationIssue {
+                card_id,
+                message: "duplicate id".to_owned(),
+            });
+        }
+
+        if !has_searchable_text(card) {
+            issues.push(CardValidationIssue {
+                card_id: card_id_for_issue(card),
+                message: "card has no searchable text".to_owned(),
+            });
+        }
+    }
+
+    if issues.is_empty() {
+        Ok(())
+    } else {
+        Err(CardValidationError::new(issues))
+    }
+}
+
+fn check_required_field(
+    issues: &mut Vec<CardValidationIssue>,
+    card_id: &Option<String>,
+    field: &'static str,
+    value: &str,
+) {
+    if value.trim().is_empty() {
+        issues.push(CardValidationIssue {
+            card_id: card_id.clone(),
+            message: format!("{field} is required"),
+        });
+    }
+}
+
+fn card_id_for_issue(card: &JargonCard) -> Option<String> {
+    let id = card.id.trim();
+
+    (!id.is_empty()).then(|| id.to_owned())
+}
+
+fn has_searchable_text(card: &JargonCard) -> bool {
+    [
+        card.term.as_str(),
+        card.plain.as_str(),
+        card.explanation.as_str(),
+    ]
+    .into_iter()
+    .chain(card.examples.iter().map(String::as_str))
+    .chain(card.queries.iter().map(String::as_str))
+    .chain(card.tags.iter().map(String::as_str))
+    .any(|item| !item.trim().is_empty())
 }
 
 pub fn normalize_query(input: &str, max_chars: usize) -> Result<String, SearchQueryError> {
@@ -245,5 +351,67 @@ mod tests {
             load_cards_from_reader("not json".as_bytes()),
             Err(CardLoadError::Json(_))
         ));
+    }
+
+    #[test]
+    fn validate_cards_accepts_fixture_cards() {
+        assert_eq!(validate_cards(&fixture_cards()), Ok(()));
+    }
+
+    #[test]
+    fn validate_cards_rejects_blank_required_fields() {
+        let mut card = card();
+        card.id = " ".to_owned();
+        card.term = " ".to_owned();
+
+        let error = validate_cards(&[card]).unwrap_err();
+
+        assert!(
+            error
+                .issues
+                .iter()
+                .any(|issue| issue.message == "id is required")
+        );
+        assert!(
+            error
+                .issues
+                .iter()
+                .any(|issue| issue.message == "term is required")
+        );
+    }
+
+    #[test]
+    fn validate_cards_rejects_duplicate_ids() {
+        let card = card();
+        let duplicate = card.clone();
+
+        let error = validate_cards(&[card, duplicate]).unwrap_err();
+
+        assert!(
+            error
+                .issues
+                .iter()
+                .any(|issue| issue.message == "duplicate id")
+        );
+    }
+
+    #[test]
+    fn validate_cards_rejects_cards_without_searchable_text() {
+        let mut card = card();
+        card.term.clear();
+        card.plain.clear();
+        card.explanation.clear();
+        card.examples.clear();
+        card.queries.clear();
+        card.tags.clear();
+
+        let error = validate_cards(&[card]).unwrap_err();
+
+        assert!(
+            error
+                .issues
+                .iter()
+                .any(|issue| issue.message == "card has no searchable text")
+        );
     }
 }

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -7,3 +7,4 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+satori-core = { path = "../core" }

--- a/crates/indexer/src/main.rs
+++ b/crates/indexer/src/main.rs
@@ -1,4 +1,20 @@
+use anyhow::Context;
+use satori_core::{load_cards_from_reader, validate_cards};
+use std::{env, fs::File};
+
+const DEFAULT_CARDS_PATH: &str = "data/processed/cards.json";
+
 fn main() -> anyhow::Result<()> {
-    // TODO: Build LanceDB indexes from processed jargon cards.
+    let cards_path = env::args()
+        .nth(1)
+        .unwrap_or_else(|| DEFAULT_CARDS_PATH.to_owned());
+    let cards_file =
+        File::open(&cards_path).with_context(|| format!("failed to open {cards_path}"))?;
+    let cards = load_cards_from_reader(cards_file)
+        .with_context(|| format!("failed to load jargon cards from {cards_path}"))?;
+
+    validate_cards(&cards)?;
+
+    println!("validated {} card(s) from {cards_path}", cards.len());
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add reusable card validation in satori-core.
- Detect blank required fields, duplicate ids, and cards without searchable text.
- Make satori-indexer validate processed card JSON files.
- Document local validation commands in README.

## Tests
- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo run -p satori-indexer
- cargo run -p satori-indexer -- tests/fixtures/cards.json

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local card data validation command to verify card integrity and completeness
  * Validation checks for missing required fields, duplicate IDs, and ensures cards contain searchable content
  * Support for validating custom card JSON files via command-line argument

* **Documentation**
  * Updated setup instructions with validation steps and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->