### PR TITLE
feat: import external jargon corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 .env.*
 data/index/
 data/raw/
+data/processed/imported/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "satori-core",
+ "serde_json",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ cargo test --workspace
 cargo run -p satori-indexer
 ```
 
+导入外部语料。
+
+```bash
+mkdir -p data/raw/mcsrainbow
+curl -L https://raw.githubusercontent.com/mcsrainbow/chinese-internet-jargon/master/readme.md \
+  -o data/raw/mcsrainbow/readme.md
+cargo run -p satori-indexer -- import-mcsrainbow
+```
+
+导入结果会写入 `data/processed/imported/mcsrainbow_cards.json`。
+
+`data/raw` 和 `data/processed/imported` 默认不提交。
+
 启动 API 服务。
 
 ```bash
@@ -143,6 +156,12 @@ SATORI_CARDS_PATH=tests/fixtures/cards.json cargo run -p satori-api
 
 ```bash
 cargo run -p satori-indexer -- tests/fixtures/cards.json
+```
+
+也可以校验导入结果。
+
+```bash
+cargo run -p satori-indexer -- validate data/processed/imported/mcsrainbow_cards.json
 ```
 
 检查健康状态。
@@ -174,7 +193,7 @@ tests/
 
 `crates/core` 提供检索卡片、搜索结果和基础排序逻辑。
 
-`crates/indexer` 目前提供本地语料校验命令。
+`crates/indexer` 目前提供本地语料校验和外部语料导入命令。
 
 当前搜索实现读取本地 JSON 卡片，并使用简单关键词排序。
 

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 satori-core = { path = "../core" }
+serde_json.workspace = true

--- a/crates/indexer/src/main.rs
+++ b/crates/indexer/src/main.rs
@@ -1,13 +1,28 @@
 use anyhow::Context;
-use satori_core::{load_cards_from_reader, validate_cards};
-use std::{env, fs::File};
+use satori_core::{JargonCard, load_cards_from_reader, validate_cards};
+use std::{
+    collections::HashSet,
+    env,
+    fs::{self, File},
+    path::Path,
+};
 
 const DEFAULT_CARDS_PATH: &str = "data/processed/cards.json";
+const DEFAULT_SOURCE: &str = "mcsrainbow/chinese-internet-jargon";
 
 fn main() -> anyhow::Result<()> {
-    let cards_path = env::args()
-        .nth(1)
-        .unwrap_or_else(|| DEFAULT_CARDS_PATH.to_owned());
+    let args = env::args().skip(1).collect::<Vec<_>>();
+
+    match args.first().map(String::as_str) {
+        Some("import-mcsrainbow") => import_mcsrainbow(&args[1..]),
+        Some("validate") => validate_command(args.get(1).map(String::as_str)),
+        Some(path) => validate_command(Some(path)),
+        None => validate_command(None),
+    }
+}
+
+fn validate_command(path: Option<&str>) -> anyhow::Result<()> {
+    let cards_path = path.unwrap_or(DEFAULT_CARDS_PATH);
     let cards_file =
         File::open(&cards_path).with_context(|| format!("failed to open {cards_path}"))?;
     let cards = load_cards_from_reader(cards_file)
@@ -17,4 +32,159 @@ fn main() -> anyhow::Result<()> {
 
     println!("validated {} card(s) from {cards_path}", cards.len());
     Ok(())
+}
+
+fn import_mcsrainbow(args: &[String]) -> anyhow::Result<()> {
+    let input_path = args
+        .first()
+        .map(String::as_str)
+        .unwrap_or("data/raw/mcsrainbow/readme.md");
+    let output_path = args
+        .get(1)
+        .map(String::as_str)
+        .unwrap_or("data/processed/imported/mcsrainbow_cards.json");
+    let markdown =
+        fs::read_to_string(input_path).with_context(|| format!("failed to read {input_path}"))?;
+    let cards = parse_mcsrainbow_markdown(&markdown);
+
+    validate_cards(&cards)?;
+    write_cards(output_path, &cards)?;
+
+    println!("imported {} card(s) into {output_path}", cards.len());
+    Ok(())
+}
+
+fn write_cards(path: &str, cards: &[JargonCard]) -> anyhow::Result<()> {
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let json = serde_json::to_string_pretty(cards).context("failed to serialize cards")?;
+    let temp_path = format!("{path}.tmp");
+
+    fs::write(&temp_path, format!("{json}\n"))
+        .with_context(|| format!("failed to write {temp_path}"))?;
+    fs::rename(&temp_path, path)
+        .with_context(|| format!("failed to move {temp_path} to {path}"))?;
+
+    Ok(())
+}
+
+fn parse_mcsrainbow_markdown(markdown: &str) -> Vec<JargonCard> {
+    let mut cards = Vec::new();
+    let mut seen_terms = HashSet::new();
+    let mut in_explanation_section = false;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('#') {
+            in_explanation_section = trimmed.contains("解释") && !trimmed.contains("翻译");
+            continue;
+        }
+
+        if !in_explanation_section {
+            continue;
+        }
+
+        let Some((term, explanation)) = parse_explanation_line(trimmed) else {
+            continue;
+        };
+
+        if !seen_terms.insert(term.to_owned()) {
+            continue;
+        }
+
+        cards.push(JargonCard {
+            id: imported_card_id(&term),
+            term,
+            plain: explanation.clone(),
+            explanation: explanation.clone(),
+            examples: Vec::new(),
+            queries: vec![explanation],
+            tags: vec!["external".to_owned(), "jargon".to_owned()],
+            source: DEFAULT_SOURCE.to_owned(),
+            verified: false,
+        });
+    }
+
+    cards
+}
+
+fn parse_explanation_line(line: &str) -> Option<(String, String)> {
+    let normalized = line
+        .trim_start_matches(|item: char| item == '-' || item == '*' || item.is_whitespace())
+        .trim();
+    let (term, explanation) = normalized
+        .split_once(" - ")
+        .or_else(|| normalized.split_once(" — "))
+        .or_else(|| normalized.split_once("："))?;
+    let term = term.trim();
+    let explanation = explanation.trim();
+
+    if term.is_empty() || explanation.is_empty() {
+        return None;
+    }
+
+    Some((term.to_owned(), explanation.to_owned()))
+}
+
+fn imported_card_id(term: &str) -> String {
+    format!("jargon_mcsrainbow_{:016x}", stable_hash(term.as_bytes()))
+}
+
+fn stable_hash(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325_u64;
+
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_mcsrainbow_markdown_imports_explanation_lines() {
+        let markdown = r#"
+# 二字黑话词汇解释
+赋能 - 提供帮助或支持。
+闭环 - 把事情从开始做到结束。
+
+# 二字黑话词汇翻译
+赋能 - enable
+"#;
+
+        let cards = parse_mcsrainbow_markdown(markdown);
+
+        assert_eq!(cards.len(), 2);
+        assert_eq!(cards[0].term, "赋能");
+        assert_eq!(cards[0].plain, "提供帮助或支持。");
+        assert!(!cards[0].verified);
+    }
+
+    #[test]
+    fn parse_mcsrainbow_markdown_skips_duplicate_terms() {
+        let markdown = r#"
+# 词汇解释
+赋能 - 提供帮助或支持。
+赋能 - 重复内容。
+"#;
+
+        let cards = parse_mcsrainbow_markdown(markdown);
+
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].plain, "提供帮助或支持。");
+    }
+
+    #[test]
+    fn imported_card_id_is_stable() {
+        assert_eq!(imported_card_id("赋能"), imported_card_id("赋能"));
+        assert_ne!(imported_card_id("赋能"), imported_card_id("闭环"));
+    }
 }

--- a/crates/indexer/src/main.rs
+++ b/crates/indexer/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{Context, bail};
 use satori_core::{JargonCard, load_cards_from_reader, validate_cards};
 use std::{
     collections::HashSet,
@@ -16,7 +16,8 @@ fn main() -> anyhow::Result<()> {
     match args.first().map(String::as_str) {
         Some("import-mcsrainbow") => import_mcsrainbow(&args[1..]),
         Some("validate") => validate_command(args.get(1).map(String::as_str)),
-        Some(path) => validate_command(Some(path)),
+        Some(path) if Path::new(path).exists() => validate_command(Some(path)),
+        Some(command) => bail!("unrecognized command or missing file: {command}"),
         None => validate_command(None),
     }
 }
@@ -134,6 +135,7 @@ fn imported_card_id(term: &str) -> String {
     format!("jargon_mcsrainbow_{:016x}", stable_hash(term.as_bytes()))
 }
 
+// FNV-1a 64-bit keeps imported IDs stable across platforms.
 fn stable_hash(bytes: &[u8]) -> u64 {
     let mut hash = 0xcbf29ce484222325_u64;
 


### PR DESCRIPTION
Closes #7

## Changes
- Add import-mcsrainbow command for local corpus import.
- Parse mcsrainbow markdown explanation lines into JargonCard JSON.
- Generate stable imported card IDs and mark imported cards as unverified.
- Keep raw and imported external data out of git by default.
- Document the local import and validation workflow in README.

## Verification
- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo run -p satori-indexer -- import-mcsrainbow
- cargo run -p satori-indexer -- validate data/processed/imported/mcsrainbow_cards.json

## Data note
The imported corpus output is not committed because the source license is unclear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an import subcommand to bring in the external Chinese internet-jargon corpus and a subcommand-based CLI.

* **Documentation**
  * Added step-by-step import and validation instructions and documented where import output is placed.

* **Chores**
  * Updated ignore rules to exclude processed/imported data from version control.
  * Added a dependency to support import/serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->