### PR TITLE
test: expand search regression suite

### DIFF
--- a/crates/api/tests/regression.rs
+++ b/crates/api/tests/regression.rs
@@ -12,7 +12,8 @@ use tower::ServiceExt;
 #[derive(Debug, Deserialize)]
 struct RegressionCase {
     query: String,
-    expected_ids: Vec<String>,
+    expected_id: String,
+    max_rank: usize,
 }
 
 #[tokio::test]
@@ -40,16 +41,16 @@ async fn regression_queries_keep_expected_ids_in_top_results() {
             .as_array()
             .unwrap()
             .iter()
-            .take(3)
+            .take(case.max_rank)
             .filter_map(|item| item["id"].as_str())
             .collect::<Vec<_>>();
 
         assert!(
-            case.expected_ids
-                .iter()
-                .any(|expected_id| result_ids.contains(&expected_id.as_str())),
-            "query {:?} did not keep expected ids in top results: {:?}",
+            result_ids.contains(&case.expected_id.as_str()),
+            "query {:?} did not keep expected id {:?} within top {} results: {:?}",
             case.query,
+            case.expected_id,
+            case.max_rank,
             result_ids
         );
     }

--- a/crates/api/tests/regression.rs
+++ b/crates/api/tests/regression.rs
@@ -26,8 +26,9 @@ async fn regression_queries_keep_expected_ids_in_top_results() {
             .oneshot(
                 Request::builder()
                     .uri(format!(
-                        "/api/search?q={}",
-                        urlencoding::encode(&case.query)
+                        "/api/search?q={}&limit={}",
+                        urlencoding::encode(&case.query),
+                        case.max_rank
                     ))
                     .body(Body::empty())
                     .unwrap(),

--- a/crates/api/tests/smoke.rs
+++ b/crates/api/tests/smoke.rs
@@ -5,7 +5,7 @@ use axum::{
 use satori_api::{AppState, app};
 use satori_core::{JargonCard, load_cards_from_reader};
 use serde_json::Value;
-use std::{fs::File, path::PathBuf};
+use std::{collections::BTreeSet, fs, fs::File, path::PathBuf};
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -29,15 +29,19 @@ async fn health_endpoint_returns_ok_status() {
 }
 
 fn fixture_cards() -> Vec<JargonCard> {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("..")
-        .join("..")
+    let path = repo_root()
         .join("tests")
         .join("fixtures")
         .join("cards.json");
     let file = File::open(path).unwrap();
 
     load_cards_from_reader(file).unwrap()
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
 }
 
 #[tokio::test]
@@ -92,4 +96,43 @@ async fn search_endpoint_honors_limit_parameter() {
     assert_eq!(payload["query"], "心态崩了");
     assert_eq!(payload["results"].as_array().unwrap().len(), 1);
     assert_eq!(payload["results"][0]["id"], "meme_po_fang_le");
+}
+
+#[test]
+fn processed_cards_match_fixture_card_ids() {
+    let fixture_ids = load_card_ids(
+        repo_root()
+            .join("tests")
+            .join("fixtures")
+            .join("cards.json"),
+    );
+    let processed_ids = load_card_ids(
+        repo_root()
+            .join("data")
+            .join("processed")
+            .join("cards.json"),
+    );
+
+    let missing_in_processed = fixture_ids
+        .difference(&processed_ids)
+        .cloned()
+        .collect::<Vec<_>>();
+    let missing_in_fixtures = processed_ids
+        .difference(&fixture_ids)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    assert!(
+        missing_in_processed.is_empty() && missing_in_fixtures.is_empty(),
+        "card corpus drift detected: missing in processed = {:?}, missing in fixtures = {:?}",
+        missing_in_processed,
+        missing_in_fixtures
+    );
+}
+
+fn load_card_ids(path: PathBuf) -> BTreeSet<String> {
+    let contents = fs::read_to_string(path).unwrap();
+    let cards: Vec<JargonCard> = serde_json::from_str(&contents).unwrap();
+
+    cards.into_iter().map(|card| card.id).collect()
 }

--- a/crates/api/tests/smoke.rs
+++ b/crates/api/tests/smoke.rs
@@ -68,3 +68,28 @@ async fn search_endpoint_returns_expected_shape() {
     assert_eq!(payload["results"][0]["term"], expected_term);
     assert!(payload["results"][0]["score"].is_number());
 }
+
+#[tokio::test]
+async fn search_endpoint_honors_limit_parameter() {
+    let response = app(AppState::new(fixture_cards()))
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/search?q={}&limit=1",
+                    urlencoding::encode("心态崩了")
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(payload["query"], "心态崩了");
+    assert_eq!(payload["results"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["results"][0]["id"], "meme_po_fang_le");
+}

--- a/data/processed/cards.json
+++ b/data/processed/cards.json
@@ -15,5 +15,56 @@
     "tags": ["职场", "会议", "协作"],
     "source": "manual",
     "verified": true
+  },
+  {
+    "id": "jargon_fu_pan",
+    "term": "复盘",
+    "plain": "总结这次哪里做得好哪里做得不好",
+    "explanation": "把已经做完的事情重新梳理，分析问题和经验。",
+    "examples": [
+      "活动结束后我们明天一起复盘。"
+    ],
+    "queries": [
+      "认真总结哪里出了问题",
+      "回头分析这次过程",
+      "总结经验教训"
+    ],
+    "tags": ["职场", "总结", "项目"],
+    "source": "manual",
+    "verified": true
+  },
+  {
+    "id": "meme_zheng_huo",
+    "term": "整活",
+    "plain": "故意搞点有节目效果的事",
+    "explanation": "为了好玩、吸引注意或者制造效果，刻意搞出有戏剧性的内容。",
+    "examples": [
+      "他直播的时候又开始整活了。"
+    ],
+    "queries": [
+      "故意搞点节目效果",
+      "为了好玩搞点事情",
+      "来点有梗的操作"
+    ],
+    "tags": ["网络", "直播", "搞笑"],
+    "source": "manual",
+    "verified": true
+  },
+  {
+    "id": "meme_po_fang_le",
+    "term": "破防了",
+    "plain": "心态崩了",
+    "explanation": "原本还能撑住，但被某句话或某件事戳中后情绪明显绷不住。",
+    "examples": [
+      "看到结局那一刻我真的破防了。"
+    ],
+    "queries": [
+      "情绪一下子绷不住了",
+      "心态突然崩掉",
+      "被一句话戳中之后难受"
+    ],
+    "tags": ["网络", "情绪", "表达"],
+    "source": "manual",
+    "verified": true
   }
 ]

--- a/tests/fixtures/cards.json
+++ b/tests/fixtures/cards.json
@@ -15,5 +15,56 @@
     "tags": ["职场", "会议", "协作"],
     "source": "manual",
     "verified": true
+  },
+  {
+    "id": "jargon_fu_pan",
+    "term": "复盘",
+    "plain": "总结这次哪里做得好哪里做得不好",
+    "explanation": "把已经做完的事情重新梳理，分析问题和经验。",
+    "examples": [
+      "活动结束后我们明天一起复盘。"
+    ],
+    "queries": [
+      "认真总结哪里出了问题",
+      "回头分析这次过程",
+      "总结经验教训"
+    ],
+    "tags": ["职场", "总结", "项目"],
+    "source": "manual",
+    "verified": true
+  },
+  {
+    "id": "meme_zheng_huo",
+    "term": "整活",
+    "plain": "故意搞点有节目效果的事",
+    "explanation": "为了好玩、吸引注意或者制造效果，刻意搞出有戏剧性的内容。",
+    "examples": [
+      "他直播的时候又开始整活了。"
+    ],
+    "queries": [
+      "故意搞点节目效果",
+      "为了好玩搞点事情",
+      "来点有梗的操作"
+    ],
+    "tags": ["网络", "直播", "搞笑"],
+    "source": "manual",
+    "verified": true
+  },
+  {
+    "id": "meme_po_fang_le",
+    "term": "破防了",
+    "plain": "心态崩了",
+    "explanation": "原本还能撑住，但被某句话或某件事戳中后情绪明显绷不住。",
+    "examples": [
+      "看到结局那一刻我真的破防了。"
+    ],
+    "queries": [
+      "情绪一下子绷不住了",
+      "心态突然崩掉",
+      "被一句话戳中之后难受"
+    ],
+    "tags": ["网络", "情绪", "表达"],
+    "source": "manual",
+    "verified": true
   }
 ]

--- a/tests/fixtures/regression.json
+++ b/tests/fixtures/regression.json
@@ -1,6 +1,22 @@
 [
   {
     "query": "大家先统一想法",
-    "expected_ids": ["jargon_lar_tong_dui_qi"]
+    "expected_id": "jargon_lar_tong_dui_qi",
+    "max_rank": 1
+  },
+  {
+    "query": "认真总结哪里出了问题",
+    "expected_id": "jargon_fu_pan",
+    "max_rank": 1
+  },
+  {
+    "query": "故意搞点节目效果",
+    "expected_id": "meme_zheng_huo",
+    "max_rank": 1
+  },
+  {
+    "query": "心态崩了",
+    "expected_id": "meme_po_fang_le",
+    "max_rank": 1
   }
 ]


### PR DESCRIPTION
Closes #9

## Summary
- expand the committed stable card corpus from one card to four cards
- add regression cases for both workplace jargon and meme lookups
- tighten regression expectations with explicit max-rank checks
- add a smoke test that verifies the search limit parameter remains stable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new Chinese vocabulary cards with definitions, examples, search phrases, tags, and verification metadata.

* **Tests**
  * Added smoke tests validating search behavior for non-ASCII queries, limit parameter handling, and fixture/card corpus consistency.
  * Enhanced regression tests to validate single expected result within a configurable max-rank across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->