### PR TITLE
feat: export index documents

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -26,6 +26,41 @@ impl JargonCard {
         ]
         .join(" ")
     }
+
+    pub fn index_document(&self) -> IndexDocument {
+        IndexDocument::from_card(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexDocument {
+    pub id: String,
+    pub term: String,
+    pub plain: String,
+    pub explanation: String,
+    pub tags: Vec<String>,
+    pub source: String,
+    pub verified: bool,
+    pub content: String,
+}
+
+impl IndexDocument {
+    pub fn from_card(card: &JargonCard) -> Self {
+        Self {
+            id: card.id.clone(),
+            term: card.term.clone(),
+            plain: card.plain.clone(),
+            explanation: card.explanation.clone(),
+            tags: card.tags.clone(),
+            source: card.source.clone(),
+            verified: card.verified,
+            content: build_index_content(card),
+        }
+    }
+}
+
+pub fn build_index_documents(cards: &[JargonCard]) -> Vec<IndexDocument> {
+    cards.iter().map(JargonCard::index_document).collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -211,6 +246,37 @@ fn has_searchable_text(card: &JargonCard) -> bool {
     .any(|item| !item.trim().is_empty())
 }
 
+fn build_index_content(card: &JargonCard) -> String {
+    let mut sections = vec![
+        format!("term: {}", card.term.trim()),
+        format!("plain: {}", card.plain.trim()),
+        format!("explanation: {}", card.explanation.trim()),
+    ];
+
+    if !card.examples.is_empty() {
+        sections.push(format!("examples: {}", join_non_empty(&card.examples)));
+    }
+
+    if !card.queries.is_empty() {
+        sections.push(format!("queries: {}", join_non_empty(&card.queries)));
+    }
+
+    if !card.tags.is_empty() {
+        sections.push(format!("tags: {}", join_non_empty(&card.tags)));
+    }
+
+    sections.join("\n")
+}
+
+fn join_non_empty(items: &[String]) -> String {
+    items
+        .iter()
+        .map(|item| item.trim())
+        .filter(|item| !item.is_empty())
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
 pub fn normalize_query(input: &str, max_chars: usize) -> Result<String, SearchQueryError> {
     let query = input.trim();
 
@@ -298,6 +364,20 @@ mod tests {
         assert!(text.contains(&card.term));
         assert!(text.contains(&card.plain));
         assert!(card.tags.iter().any(|tag| text.contains(tag)));
+    }
+
+    #[test]
+    fn index_document_contains_stable_content_sections() {
+        let card = card();
+        let document = card.index_document();
+
+        assert_eq!(document.id, card.id);
+        assert!(document.content.contains("term: "));
+        assert!(document.content.contains("plain: "));
+        assert!(document.content.contains("explanation: "));
+        assert!(document.content.contains("examples: "));
+        assert!(document.content.contains("queries: "));
+        assert!(document.content.contains("tags: "));
     }
 
     #[test]

--- a/crates/indexer/src/main.rs
+++ b/crates/indexer/src/main.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, bail};
-use satori_core::{JargonCard, load_cards_from_reader, validate_cards};
+use satori_core::{
+    IndexDocument, JargonCard, build_index_documents, load_cards_from_reader, validate_cards,
+};
 use std::{
     collections::HashSet,
     env,
     fs::{self, File},
+    io::{BufWriter, Write},
     path::Path,
 };
 
@@ -15,6 +18,7 @@ fn main() -> anyhow::Result<()> {
 
     match args.first().map(String::as_str) {
         Some("import-mcsrainbow") => import_mcsrainbow(&args[1..]),
+        Some("export-index-docs") => export_index_docs_command(&args[1..]),
         Some("validate") => validate_command(args.get(1).map(String::as_str)),
         Some(path) if Path::new(path).exists() => validate_command(Some(path)),
         Some(command) => bail!("unrecognized command or missing file: {command}"),
@@ -55,6 +59,33 @@ fn import_mcsrainbow(args: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn export_index_docs_command(args: &[String]) -> anyhow::Result<()> {
+    let input_path = args
+        .first()
+        .map(String::as_str)
+        .unwrap_or(DEFAULT_CARDS_PATH);
+    let output_path = args
+        .get(1)
+        .map(String::as_str)
+        .unwrap_or("data/processed/index_docs.jsonl");
+    let cards = load_cards(input_path)?;
+    let documents = build_index_documents(&cards);
+
+    write_index_documents(output_path, &documents)?;
+    println!(
+        "exported {} index document(s) into {output_path}",
+        documents.len()
+    );
+
+    Ok(())
+}
+
+fn load_cards(path: &str) -> anyhow::Result<Vec<JargonCard>> {
+    let cards_file = File::open(path).with_context(|| format!("failed to open {path}"))?;
+    load_cards_from_reader(cards_file)
+        .with_context(|| format!("failed to load jargon cards from {path}"))
+}
+
 fn write_cards(path: &str, cards: &[JargonCard]) -> anyhow::Result<()> {
     if let Some(parent) = Path::new(path).parent() {
         fs::create_dir_all(parent)
@@ -66,6 +97,34 @@ fn write_cards(path: &str, cards: &[JargonCard]) -> anyhow::Result<()> {
 
     fs::write(&temp_path, format!("{json}\n"))
         .with_context(|| format!("failed to write {temp_path}"))?;
+    fs::rename(&temp_path, path)
+        .with_context(|| format!("failed to move {temp_path} to {path}"))?;
+
+    Ok(())
+}
+
+fn write_index_documents(path: &str, documents: &[IndexDocument]) -> anyhow::Result<()> {
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let temp_path = format!("{path}.tmp");
+    let temp_file =
+        File::create(&temp_path).with_context(|| format!("failed to create {temp_path}"))?;
+    let mut writer = BufWriter::new(temp_file);
+
+    for document in documents {
+        serde_json::to_writer(&mut writer, document)
+            .context("failed to serialize index document")?;
+        writer
+            .write_all(b"\n")
+            .with_context(|| format!("failed to write {temp_path}"))?;
+    }
+
+    writer
+        .flush()
+        .with_context(|| format!("failed to flush {temp_path}"))?;
     fs::rename(&temp_path, path)
         .with_context(|| format!("failed to move {temp_path} to {path}"))?;
 
@@ -237,6 +296,7 @@ fn stable_hash(bytes: &[u8]) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn parse_mcsrainbow_markdown_imports_explanation_lines() {
@@ -315,5 +375,36 @@ mod tests {
     fn imported_card_id_is_stable() {
         assert_eq!(imported_card_id("赋能"), imported_card_id("赋能"));
         assert_ne!(imported_card_id("赋能"), imported_card_id("闭环"));
+    }
+
+    #[test]
+    fn write_index_documents_writes_jsonl_rows() {
+        let cards =
+            load_cards_from_reader(include_str!("../../../tests/fixtures/cards.json").as_bytes())
+                .unwrap();
+        let documents = build_index_documents(&cards);
+        let temp_path = unique_temp_path("index-docs.jsonl");
+
+        write_index_documents(temp_path.to_str().unwrap(), &documents).unwrap();
+
+        let contents = fs::read_to_string(&temp_path).unwrap();
+        let lines = contents.lines().collect::<Vec<_>>();
+
+        assert_eq!(lines.len(), documents.len());
+
+        let first: IndexDocument = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first.id, "jargon_lar_tong_dui_qi");
+        assert!(first.content.contains("term: 拉通对齐"));
+
+        fs::remove_file(temp_path).unwrap();
+    }
+
+    fn unique_temp_path(name: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        env::temp_dir().join(format!("satori-{nanos}-{name}"))
     }
 }


### PR DESCRIPTION
Closes #15

## Summary
- add a stable `IndexDocument` shape in core derived from processed cards
- add an `export-index-docs` indexer command that writes JSONL documents
- build deterministic index content from labeled card sections
- cover index document generation and JSONL export behavior with tests